### PR TITLE
Travis updates to make OSX passing optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,18 @@ env:
 
 # OSX matrix
 matrix:
+    fast_finish: true
     include:
+        - os: osx
+          osx_image: xcode10.1
+          language: generic
+          env: PYTHON_VERSION=python2 MPI=
+        - os: osx
+          osx_image: xcode10.1
+          language: generic
+          env: PYTHON_VERSION=python3 MPI=
+
+    allow_failures:
         - os: osx
           osx_image: xcode10.1
           language: generic


### PR DESCRIPTION
OSX is unstable on travis. Better to make OSX passing optional for now.


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code is PEP8 compliant (`flake8 pybambi tests`)
- [x] My code contains compliant docstrings (`sphinx-build docs/source docs/build -nW; pydocstyle pybambi`)
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`)
- [x] I have added tests that prove my fix is effective or that my feature works